### PR TITLE
Properly center canvas

### DIFF
--- a/site/plugins/pixels/assets/css/canvas.css
+++ b/site/plugins/pixels/assets/css/canvas.css
@@ -1,5 +1,6 @@
 .canvas {
-	position: relative;
+	position: absolute;
+	inset: 50% 50%;
 	background-color: var(--color-light);
 	overflow: hidden;
 	color: var(--color-white);

--- a/site/plugins/pixels/assets/css/pixels.css
+++ b/site/plugins/pixels/assets/css/pixels.css
@@ -11,13 +11,11 @@ body {
 .pixels {
 	display: grid;
 	height: 100%;
-	grid-template-columns: 20rem 2fr;
+	grid-template-columns: 20rem 1fr;
 }
 
 main {
 	position: relative;
-	display: grid;
-	place-items: center;
 }
 
 .exporter {

--- a/site/plugins/pixels/snippets/canvas.php
+++ b/site/plugins/pixels/snippets/canvas.php
@@ -3,7 +3,7 @@
 		width: settings.width + 'px',
 		height: settings.height + 'px',
 		color: settings.color,
-		transform: 'scale(' +  settings.zoom + ')'
+		transform: 'translate(-50%, -50%) scale(' +  settings.zoom + ')'
 	}">
 
 	<div


### PR DESCRIPTION
Now, in the main section there's equal space left and right.

Avoiding this off-center look:
<img width="1466" alt="Screenshot 2025-01-27 at 09 09 15" src="https://github.com/user-attachments/assets/eb30e93e-4c1b-42f9-8bfb-09478801e7e2" />


@bastianallgeier Please check if that's right also for large screens.